### PR TITLE
invalidate grant statement of 'GRANT ALL ON SEQUENCES IN SCHEMA'

### DIFF
--- a/doc_source/CHAP_Oracle2PostgreSQL.Steps.ConfigurePostgreSQL.md
+++ b/doc_source/CHAP_Oracle2PostgreSQL.Steps.ConfigurePostgreSQL.md
@@ -17,5 +17,5 @@
    GRANT CONNECT ON DATABASE database_name TO postgresql_sct_user;
    GRANT USAGE ON SCHEMA schema_name TO postgresql_sct_user;
    GRANT SELECT ON ALL TABLES IN SCHEMA schema_name TO postgresql_sct_user;
-   GRANT ALL ON SEQUENCES IN SCHEMA schema_name TO postgresql_sct_user;
+   GRANT ALL ON ALL SEQUENCES IN SCHEMA schema_name TO postgresql_sct_user;
    ```


### PR DESCRIPTION
"GRANT ALL ON SEQUENCES IN SCHEMA schema_name TO postgresql_sct_user;" will get syntax error at or near "IN". The correct one is GRANT ALL ON ALL SEQUENCES IN SCHEMA schema_name TO postgresql_sct_user;

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
